### PR TITLE
Add CircleCI configuration and restore Gradle wrapper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/openjdk:21.0
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-gradle-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "lib/build.gradle" }}
+      - run:
+          name: Run Build
+          command: ./gradlew build
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-gradle-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "lib/build.gradle" }}
+      - store_test_results:
+          path: lib/build/test-results/test
+      - store_artifacts:
+          path: lib/build/reports/tests/test
+          destination: test-reports
+
+workflows:
+  build_and_test:
+    jobs:
+      - build


### PR DESCRIPTION
This PR adds a CircleCI configuration file to the project. The configuration defines a 'build' job that runs on every push. It uses a Java 21 environment, leverages Gradle caching to speed up subsequent builds, and automatically collects test results and HTML reports for better visibility within the CircleCI dashboard. Additionally, it restores the 'gradle-wrapper.jar' which was missing from the repository, ensuring that the './gradlew' command can be executed in CI and by other developers.

Fixes #5

---
*PR created automatically by Jules for task [5437574404642924810](https://jules.google.com/task/5437574404642924810) started by @boxheed*